### PR TITLE
Add support for .webp and links with query strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ wrapper.LongTermRateLimiter = new RateLimiter(imagesPerCycle, new TimeSpan(hours
 
 
 ## Notes
-- Only .png, .jpeg, .jpg, .bmp, and .gif images are supported
+- Only .png, .jpeg, .jpg, .bmp, .gif and .webp images are supported
 - DefaultReponseType exists in case the SauceNao developer(s) ever implement the XML output type (highly doubtful).
   Setting it to normal will just return a normal html search. The wrapper is not currently setup to deal with this (potentially in the future).
   

--- a/SharpNao.cs
+++ b/SharpNao.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -274,8 +273,16 @@ namespace Laz.Api
             if(!(Uri.TryCreate(sauceUrl, UriKind.Absolute, out Uri uri) && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)))
                 return new KeyValuePair<string, SourceResult[]>("Url supplied was not valid.", new SourceResult[0]);
 
-            if (AllowedFileTypes.All(x => x != Path.GetExtension(sauceUrl)))
-                return new KeyValuePair<string, SourceResult[]>("File provided was not of a valid format.", new SourceResult[0]);
+            {
+                string extension = Path.GetExtension(sauceUrl);
+
+                int index = extension.IndexOf('?');
+                if(index > 0)
+                    extension = extension.Substring(0, index);
+
+                if (AllowedFileTypes.All(x => x != extension))
+                    return new KeyValuePair<string, SourceResult[]>("File provided was not of a valid format.", new SourceResult[0]);
+            }
 
             if (results == 0)
                 results = DefaultResultCount;

--- a/SharpNao.cs
+++ b/SharpNao.cs
@@ -246,7 +246,7 @@ namespace Laz.Api
         /// <summary>
         /// An array of the allowed file types. We check against these before sending the request.
         /// </summary>
-        private string[] AllowedFileTypes { get; } = new[] {".jpg", ".jpeg", ".gif", ".bmp", ".png"};
+        private string[] AllowedFileTypes { get; } = new[] {".jpg", ".jpeg", ".gif", ".bmp", ".png", ".webp"};
 
         /// <summary></summary>
         /// <param name="apiKey">Your SauceNao Api Key</param>


### PR DESCRIPTION
This PR adds support for the .webp file extension and links with query strings.
Previously it would treat the query strings as a part of the file extension.
For example, Discord avatar URLs use the `?size=1024` query string.
Before this PR SharpNao would think that the file extension is `webp?size=1024` instead of `webp`